### PR TITLE
deprovision

### DIFF
--- a/ansible/cdi_deprovision.yaml
+++ b/ansible/cdi_deprovision.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: localhost
+  vars:
+    apb_action: deprovision
+  tasks:
+    - import_role:
+       name: cdi

--- a/ansible/cdi_provision.yaml
+++ b/ansible/cdi_provision.yaml
@@ -1,5 +1,7 @@
 ---
 - hosts: localhost
+  vars:
+    apb_action: provision
   tasks:
     - import_role:
        name: cdi

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -2,5 +2,3 @@ apiVersion: "cache.example.com/v1alpha1"
 kind: "CDI"
 metadata:
   name: "cdi"
-spec:
-  apb_action: provision

--- a/watches.yaml
+++ b/watches.yaml
@@ -2,4 +2,7 @@
 - version: v1alpha1
   group: cache.example.com
   kind: CDI
-  playbook: /opt/ansible/cdi.yaml
+  playbook: /opt/ansible/cdi_provision.yaml
+  finalizer:
+    name: finalizer.cache.example.com
+    playbook: /opt/ansible/cdi_deprovision.yaml


### PR DESCRIPTION
Use a finalizer to trigger a different playbook
to deprovision CDI via its ansible role on delete.

Since in
https://github.com/kubevirt/kubevirt-ansible/tree/master/roles/cdi
we have a single role that can provision or deprovision
CDI according to the value of apb_action ansible variable,
let's introduce two distinct playbooks for provisioning and deprovisioning
setting apb_action value at playbook level.

Remove apb_action from spec section in cr.yml since
according to https://github.com/operator-framework/operator-sdk/blob/master/doc/ansible/dev/developer_guide.md#extra-vars-sent-to-ansible
it will be passed to ansible as an extra var and, according to
https://docs.ansible.com/ansible/2.7/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable ,
extra vars win over playbook ones.