### PR TITLE
Switch to IfNotPresent imagePullPolicy

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -18,7 +18,7 @@ spec:
           ports:
           - containerPort: 60000
             name: metrics
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
               valueFrom:


### PR DESCRIPTION
Switch to IfNotPresent imagePullPolicy to
let the locally built developement image
win over the repo one.