### PR TITLE
Setup Travis CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
-# remnove once https://github.com/fabiand/traviskube/pull/26 got merged/fixed
+# remove once https://github.com/fabiand/traviskube/pull/26 got merged/fixed
 openshift.local.clusterup

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# remnove once https://github.com/fabiand/traviskube/pull/26 got merged/fixed
+openshift.local.clusterup

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ci"]
+	path = ci
+	url = https://github.com/fabiand/traviskube

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+sudo: required
+dist: xenial
+
+branches:
+  only:
+  - master
+  - "/^v[0-9]/"
+
+env:
+  global:
+    - KUBEVIRT_VER=0.9.1
+
+jobs:
+  include:
+#    - stage: Tests
+#      name: "Default (minikube with latest k8s)"
+
+#    - name: "minikube (latest k8s)"
+#      env: CPLATFORM=minikube
+
+    - name: "oc cluster (latest okd)"
+      env: CPLATFORM=oc_cluster
+
+    - name: "minishift (latest okd)"
+      env: CPLATFORM=minishift
+
+#    - name: "minikube (K8s v1.10)"
+#      env: CPLATFORM=minikube CVER=1.10.7
+
+cache:
+  directories:
+  - cache
+  - "~/.minishift/cache"
+  - "~/.minikube/cache"
+
+before_script:
+## FIXME Workaround for https://github.com/kubernetes/kubernetes/issues/61058
+### And https://github.com/LiliC/travis-minikube/blob/e0f26f7b388057f51a0e2558afd5f990e07b6c49/.travis.yml#L11
+- sudo mount --make-rshared /
+
+- bash -x ci/prepare-host $CPLATFORM
+#- bash -x ci/prepare-host virtctl
+- bash -x ci/start-cluster $CPLATFORM $CVER
+#- bash -x ci/deploy-kubevirt $CPLATFORM
+
+script:
+- timeout 10m bash -x test.sh

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,10 @@ build: role
 push:
 	docker push $(REPO):$(TAG)
 
-.PHONY:  role build push undeploy deploy
+##############
+# Tests      #
+##############
+
+test: ;
+
+.PHONY:  role build push undeploy deploy test

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,9 @@
+ci/wait-pods-ok
+make build
+make deploy
+# give everything time to come up - PLEASE FIX
+sleep 120
+# fetch operator logs
+oc logs $(oc get pods --selector name=cdi-operator --output=name)
+# check for CDI related pods in kube-system ns
+oc get pod -o name --namespace=kube-system | grep cdi

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,5 @@
 ci/wait-pods-ok
+make test
 make build
 make deploy
 # give everything time to come up - PLEASE FIX


### PR DESCRIPTION
Setup Travis CI, based on https://github.com/fabiand/traviskube/

Currently testing only on a cluster deployed with 'oc cluster up' and minishift since we are currently requiring oc tool.

This first test suite builds the operator, deploy it and trigger CDI deployment and waits for CDI pods to correctly appear.